### PR TITLE
feat: Add GitHub Actions workflow for Go build and pre-releases

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -1,0 +1,43 @@
+name: Go Build and Pre-release
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.22'
+
+    - name: Install Gio Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libgl1-mesa-dev xorg-dev libxkbcommon-dev libwayland-dev libxcursor-dev libx11-xcb-dev libvulkan-dev
+
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Build application
+      run: go build -v -o gcs-app ./ux/gio
+
+    # This part runs only on pushes to main, not on PRs
+    - name: Create Pre-release and Upload Artifact
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: softprops/action-gh-release@v1
+      with:
+        name: Pre-release ${{ github.run_number }} (${{ github.sha }})
+        tag_name: prerelease-${{ github.run_number }}-${{ env.SHORT_SHA }}
+        body: "Automated pre-release based on commit ${{ github.sha }}."
+        prerelease: true
+        files: |
+          gcs-app
+          # Add other files like checksums if you generate them
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SHORT_SHA: $(echo ${{ github.sha }} | cut -c1-7)


### PR DESCRIPTION
This workflow will:
- Build the Go application located in ./ux/gio on every push to main and PR to main.
- Install necessary Gio dependencies.
- On pushes to main, create a GitHub pre-release with the compiled binary (gcs-app).